### PR TITLE
check the return value of select()

### DIFF
--- a/src/SFML/Window/RPi/InputImpl.cpp
+++ b/src/SFML/Window/RPi/InputImpl.cpp
@@ -384,9 +384,9 @@ namespace
         fd_set rdfs;
         FD_ZERO( &rdfs );
         FD_SET( STDIN_FILENO, &rdfs );
-        select( STDIN_FILENO+1, &rdfs, NULL, NULL, &tv );
+        int sel = select( STDIN_FILENO+1, &rdfs, NULL, NULL, &tv );
 
-        if ( FD_ISSET( STDIN_FILENO, &rdfs ) )
+        if ( sel > 0 && FD_ISSET( STDIN_FILENO, &rdfs ) )
             read( STDIN_FILENO, &c, 1 );
 
         if (( c == 127 ) || ( c == 8 ))  // Suppress 127 (DEL) to 8 (BACKSPACE)
@@ -397,8 +397,8 @@ namespace
             //
             FD_ZERO( &rdfs );
             FD_SET( STDIN_FILENO, &rdfs );
-            select( STDIN_FILENO+1, &rdfs, NULL, NULL, &tv );
-            if ( FD_ISSET( STDIN_FILENO, &rdfs ) )
+            sel = select( STDIN_FILENO+1, &rdfs, NULL, NULL, &tv );
+            if ( sel > 0 && FD_ISSET( STDIN_FILENO, &rdfs ) )
             {
                 unsigned char buff[16];
                 int rd = read( STDIN_FILENO, buff, 16 );


### PR DESCRIPTION
I was finding that my program would run for a little while, and then hang reading from stdin.  Checking that the return value of select() is greater than zero (where zero means timeout) seems to fix that problem.