### PR TITLE
CMake: Pi: update to new vendor library name

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,10 +24,12 @@ Install
 ```bash
 mkdir build
 cd build
-cmake .. -DSFML_RPI=1 -DEGL_INCLUDE_DIR=/opt/vc/include -DEGL_LIBRARY=/opt/vc/lib/libEGL.so -DGLES_INCLUDE_DIR=/opt/vc/include -DGLES_LIBRARY=/opt/vc/lib/libGLESv1_CM.so
+cmake .. -DSFML_RPI=1 -DEGL_INCLUDE_DIR=/opt/vc/include -DEGL_LIBRARY=/opt/vc/lib/libbrcmEGL.so -DGLES_INCLUDE_DIR=/opt/vc/include -DGLES_LIBRARY=/opt/vc/lib/libbrcmGLESv2.so
 sudo make install
 sudo ldconfig
 ```
+
+Note: if you are using a Pi firmware older than 1.20160921-1, please replace "libbrcmEGL.so" and "libbrcmGLESv2" with the old names, "libEGL.so" and "libGLESv2".
 
 That's it!  You should now be able to use SFML on your raspberry pi with hardware accelerated
 graphics and no need to be running X.

--- a/src/SFML/Graphics/CMakeLists.txt
+++ b/src/SFML/Graphics/CMakeLists.txt
@@ -120,7 +120,11 @@ if(SFML_OPENGL_ES AND SFML_OS_LINUX)
     if(SFML_RPI)
         # Workaround: we need to use gles2 on the rpi version
         get_filename_component(GLES2PATH ${GLES_LIBRARY} PATH)
-        find_library(GLES2_LIBRARY GLESv2 ${GLES2PATH})
+        find_library(GLES2_LIBRARY brcmGLESv2 ${GLES2PATH})
+        # fallback to old vendor library name
+        if(${GLES2_LIBRARY} STREQUAL "GLES2_LIBRARY-NOTFOUND")
+            find_library(GLES2_LIBRARY GLESv2 ${GLES2PATH})
+        endif()
     endif()
 endif()
 if(SFML_OS_ANDROID)


### PR DESCRIPTION
This will allow compatibility with Raspbian stretch, and continues
working on recent jessie firmwares (1.20160921-1 or later)