### PR TITLE
add SFML_DRM_REFRESH support to request specifc vrefresh for a mode if multiple exists

### DIFF
--- a/src/SFML/Window/Unix/DRM/DRMContext.cpp
+++ b/src/SFML/Window/Unix/DRM/DRMContext.cpp
@@ -103,11 +103,20 @@ namespace
 
         // mode: Use environment variable "SFML_DRM_MODE" (or NULL if not set)
         char *mode_str = getenv( "SFML_DRM_MODE" );
+        
+		// refresh: Use environment variable "SFML_DRM_REFRESH" (or 0 if not set)
+		// use in combination with mode to request specific refresh rate for the mode
+		// if multiple refresh rates for same mode might be supported
+		int vrefresh = 0;
+		char *refresh_str = getenv( "SFML_DRM_REFRESH" );
+
+		if (refresh_str)
+			vrefresh = atoi(refresh_str);
 
         if ( init_drm( &my_drm,
             device_str,          // device
             mode_str,            // requested mode
-            0 ) < 0 )            // vrefresh
+            vrefresh ) < 0 )     // vrefresh
         {
             sf::err() << "Error initializing drm" << std::endl;
             return;

--- a/src/SFML/Window/Unix/DRM/drm-common.c
+++ b/src/SFML/Window/Unix/DRM/drm-common.c
@@ -308,8 +308,10 @@ int init_drm(struct drm *drm, const char *device, const char *mode_str,
 
     // get original display mode so we can restore display mode after program exits
     drm->original_crtc = drmModeGetCrtc( drm->fd, drm->crtc_id );
-
-	printf("DRM Mode used: %s@%d\n", drm->mode->name, drm->mode->vrefresh);
+	
+	if(getenv( "SFML_DRM_DEBUG" )) {
+		printf("DRM Mode used: %s@%d\n", drm->mode->name, drm->mode->vrefresh);
+	}
 
 	return 0;
 }

--- a/src/SFML/Window/Unix/DRM/drm-common.c
+++ b/src/SFML/Window/Unix/DRM/drm-common.c
@@ -308,5 +308,8 @@ int init_drm(struct drm *drm, const char *device, const char *mode_str,
 
     // get original display mode so we can restore display mode after program exits
     drm->original_crtc = drmModeGetCrtc( drm->fd, drm->crtc_id );
+
+	printf("DRM Mode used: %s@%d\n", drm->mode->name, drm->mode->vrefresh);
+
 	return 0;
 }


### PR DESCRIPTION
SFML_DRM_REFRESH can be used in combination with SFML_DRM_MODE to request a specific refresh rate if multiple exists for the same requested mode, by default when only using SFML_DRM_MODE it would take the first mode found without a way to specify requested refresh rate. if SFML_DRM_REFRESH is not specified 0 is used as before.

I also added a small printf statement to printout the actual mode used in DRM mode.