### PR TITLE
Added triple buffering to DRM backend

### DIFF
--- a/src/SFML/Window/Unix/DRM/DRMContext.cpp
+++ b/src/SFML/Window/Unix/DRM/DRMContext.cpp
@@ -134,6 +134,12 @@ namespace
 
         my_drm.fd = -1;
         my_drm.mode = 0;
+
+        memset(&my_fds,     0, sizeof(struct pollfd));
+        memset(&my_evctx,   0, sizeof(drmEventContext));
+
+        waiting_for_flip = 0;
+
         initialized = false;
     }
 

--- a/src/SFML/Window/Unix/DRM/DRMContext.hpp
+++ b/src/SFML/Window/Unix/DRM/DRMContext.hpp
@@ -173,7 +173,8 @@ private:
     EGLSurface  m_surface; ///< The internal EGL surface
     EGLConfig   m_config;  ///< The internal EGL config
 
-    struct gbm_bo *m_last_bo;
+    struct gbm_bo *m_cur_bo;
+    struct gbm_bo *m_next_bo;
     struct gbm_surface *m_gbm_surface;
     int m_width;
     int m_height;


### PR DESCRIPTION
Fixes the performance degradation during page flipping when compared to Dispmanx backend which by default has triple buffering enabled.