### PR TITLE
Add standard X & Y events for EV_ABS

### DIFF
--- a/src/SFML/Window/Unix/DRM/InputImplUDev.cpp
+++ b/src/SFML/Window/Unix/DRM/InputImplUDev.cpp
@@ -469,8 +469,18 @@ namespace
                 }
                 else if ( ie.type == EV_ABS )
                 {
+                    bool posChange = false;
                     switch ( ie.code )
                     {
+                    case ABS_X:
+                        mousePos.x = ie.value;
+                        posChange = true;
+                        break;
+
+                    case ABS_Y:
+                        mousePos.y = ie.value;
+                        posChange = true;
+                        break;
                     case ABS_MT_SLOT:
                         currentSlot = ie.value;
                         touchFd = *itr;
@@ -487,6 +497,13 @@ namespace
                         atSlot(currentSlot).pos.y = ie.value;
                         touchFd = *itr;
                         break;
+                    }
+                    if ( posChange )
+                    {
+                        ev.type = sf::Event::MouseMoved;
+                        ev.mouseMove.x = mousePos.x;
+                        ev.mouseMove.y = mousePos.y;
+                        return true;
                     }
                 }
                 else if ( ie.type == EV_SYN && ie.code == SYN_REPORT &&


### PR DESCRIPTION
A Touchscreen I have hooked up to a PI emulates a mouse and sends ABS_X & ABS_Y events. Without the change attached I was getting BTN_LEFT events but the cursor was not moving.

**evtest**
Input driver version is 1.0.1
Input device ID: bus 0x6 vendor 0xeef product 0x1 version 0x1
Input device name: "eGalaxTouch Virtual Device for Single"
Supported events:
  Event type 0 (EV_SYN)
  Event type 1 (EV_KEY)
    Event code 272 (BTN_LEFT)
    Event code 273 (BTN_RIGHT)
  Event type 3 (EV_ABS)
    Event code 0 (ABS_X)
      Value    321
      Min        0
      Max     2047
    Event code 1 (ABS_Y)
      Value   1475
      Min        0
      Max     2047
    Event code 3 (ABS_RX)
      Value      0
      Min        0
      Max     2047
    Event code 4 (ABS_RY)
      Value      0
      Min        0
      Max     2047
Properties:
  Property type 1 (INPUT_PROP_DIRECT)
Testing ... (interrupt to exit)
Event: time 1601581907.752252, type 3 (EV_ABS), code 0 (ABS_X), value 1355
Event: time 1601581907.752252, type 3 (EV_ABS), code 1 (ABS_Y), value 980
Event: time 1601581907.752252, type 1 (EV_KEY), code 272 (BTN_LEFT), value 1
